### PR TITLE
Provide `HelpInitializationService`

### DIFF
--- a/src/app/public/bb-help.module.ts
+++ b/src/app/public/bb-help.module.ts
@@ -18,12 +18,19 @@ import {
   OpenOnClickDirectiveModule
 } from './modules/open-on-click-directive/open-on-click.module';
 
+import {
+  HelpInitializationService
+} from './modules/shared/initialization.service';
+
 @NgModule({
   exports: [
     HelpKeyModule,
     HelpModule,
     BBHelpDisableModule,
     OpenOnClickDirectiveModule
+  ],
+  providers: [
+    HelpInitializationService
   ]
 })
 export class BBHelpModule { }


### PR DESCRIPTION
The "shared" module (which provided the initialization service) was removed in version 3.0.0:
https://github.com/blackbaud/skyux-lib-help/compare/2.0.0...3.0.0#diff-3979037c4dbce0aace5806199476dab8L9

However, this breaks implementations if the consumer is using the initialization service in their code.