### PR TITLE
feat: deprecate undock configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ jspm_packages
 .skyuxtmp
 .srctmp
 .skypagestmp
+.skypageslocales
 
 # SKY UX build directory
 dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
 sudo: required
-dist: trusty
+
+addons:
+  chrome: stable
+
+services:
+  - xvfb
 
 git:
   depth: 10
@@ -15,9 +20,7 @@ cache:
     - node_modules
 
 before_install:
-  - export CHROME_BIN=/usr/bin/google-chrome
-  - export DISPLAY=:99.0
-  - bash <(curl -s https://blackbaud.github.io/skyux-travis/library-before-install.sh)
+  - npm install -g @blackbaud/skyux-cli
 
 after_script:
   - bash <(curl -s https://blackbaud.github.io/skyux-travis/library-after-script.sh)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.2 (2019-10-08)
+
+- Deprecate `hideUndock` configuration. [#54](https://github.com/blackbaud/skyux-lib-help/pull/54)
+
 # 3.1.1 (2019-07-25)
 
 - Fixed a bug where `HelpInitializationService` was not being provided by `BBHelpModule`. [#52](https://github.com/blackbaud/skyux-lib-help/pull/52)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/skyux-lib-help",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Angular 2 components for SKY UX Builder SPAs",
   "main": "bundles/bundle.umd.js",
   "module": "index.ts",

--- a/src/app/public/modules/shared/widget-config.ts
+++ b/src/app/public/modules/shared/widget-config.ts
@@ -12,6 +12,9 @@ export interface HelpWidgetConfig {
   helpBaseUrl?: string;
   helpCenterUrl?: string;
   hideHelpChat?: boolean | string;
+  /**
+   * @deprecated The undock component no longer exists, thus this configuration will have no effect.
+   */
   hideUndock?: boolean | string;
   hideWidgetOnMobile?: boolean;
   hostQueryParams?: string;


### PR DESCRIPTION
this configuration is deprecated and is not used.

i'd like SKY UX to weigh in on backwards compatibility before merging.