### PR TITLE
feat: add config extension capability for consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 3.3.0 (2020-03-20)
+## 3.3.0 (2020-03-24)
 
-- Add capability for extending configuration at runtime. [#56](https://github.com/blackbaud/skyux-lib-help/pull/56)
+- Bump acorn from 6.3.0 to 6.4.1 to address security vulnerability. [#56](https://github.com/blackbaud/skyux-lib-help/pull/56)
+- Add capability for extending configuration at runtime. [#56](https://github.com/blackbaud/skyux-lib-help/pull/57)
 
 ## 3.2.0 (2020-01-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 3.2.0 (2020-01-06)
+## 3.3.0 (2020-03-20)
+
+- Add capability for extending configuration at runtime. [#56](https://github.com/blackbaud/skyux-lib-help/pull/56)
+
+## 3.2.0 (2020-01-15)
 
 - Set key config values from `SkyAppConfig` and `SKYUX_HOST` (i.e. `extends`, `environmentId`, and `locale`). [#55](https://github.com/blackbaud/skyux-lib-help/pull/55)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 3.3.0 (2020-03-24)
 
 - Bump acorn from 6.3.0 to 6.4.1 to address security vulnerability. [#56](https://github.com/blackbaud/skyux-lib-help/pull/56)
-- Add capability for extending configuration at runtime. [#56](https://github.com/blackbaud/skyux-lib-help/pull/57)
+- Add capability for extending configuration at runtime. [#57](https://github.com/blackbaud/skyux-lib-help/pull/57)
 
 ## 3.2.0 (2020-01-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 ## 3.3.0 (2020-03-24)
 
-- Bump acorn from 6.3.0 to 6.4.1 to address security vulnerability. [#56](https://github.com/blackbaud/skyux-lib-help/pull/56)
-- Add capability for extending configuration at runtime. [#57](https://github.com/blackbaud/skyux-lib-help/pull/57)
+- Updated Acorn from `6.3.0` to `6.4.1` to address a security vulnerability. [#56](https://github.com/blackbaud/skyux-lib-help/pull/56)
+- Added a capability to extend the configuration at runtime. [#57](https://github.com/blackbaud/skyux-lib-help/pull/57)
 
 ## 3.2.0 (2020-01-15)
 
-- Set key config values from `SkyAppConfig` and `SKYUX_HOST` (i.e. `extends`, `environmentId`, and `locale`). [#55](https://github.com/blackbaud/skyux-lib-help/pull/55)
+- Set key config values from `SkyAppConfig` and `SKYUX_HOST` such as `extends`, `environmentId`, and `locale`. [#55](https://github.com/blackbaud/skyux-lib-help/pull/55)
 
 # 3.1.2 (2019-10-08)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # skyux-lib-help
 
-### The SKYUX library for interacting with the Help Widget.
+### The SKY UX library to interact with the Help Widget.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Skyux-Lib-Help
+# skyux-lib-help
 
 ### The SKYUX library for interacting with the Help Widget.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/skyux-lib-help",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbaud/skyux-lib-help",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Angular 2 components for SKY UX Builder SPAs",
   "main": "bundles/bundle.umd.js",
   "module": "index.ts",

--- a/src/app/public/modules/shared/config.extension.ts
+++ b/src/app/public/modules/shared/config.extension.ts
@@ -1,0 +1,8 @@
+import {Injectable} from '@angular/core';
+import {HelpWidgetConfig} from './widget-config';
+import {Observable} from 'rxjs';
+
+@Injectable()
+export abstract class ConfigExtension {
+  public abstract extend(config: HelpWidgetConfig): Observable<HelpWidgetConfig>;
+}

--- a/src/app/public/modules/shared/config.extension.ts
+++ b/src/app/public/modules/shared/config.extension.ts
@@ -1,6 +1,14 @@
-import {Injectable} from '@angular/core';
-import {HelpWidgetConfig} from './widget-config';
-import {Observable} from 'rxjs';
+import {
+  Injectable
+} from '@angular/core';
+
+import {
+  HelpWidgetConfig
+} from './widget-config';
+
+import {
+  Observable
+} from 'rxjs';
 
 @Injectable()
 export abstract class ConfigExtension {

--- a/src/app/public/modules/shared/initialization-config-extension.service.ts
+++ b/src/app/public/modules/shared/initialization-config-extension.service.ts
@@ -11,6 +11,6 @@ import {
 } from 'rxjs';
 
 @Injectable()
-export abstract class ConfigExtension {
+export abstract class InitializationConfigExtensionService {
   public abstract extend(config: HelpWidgetConfig): Observable<HelpWidgetConfig>;
 }

--- a/src/app/public/modules/shared/initialization.service.spec.ts
+++ b/src/app/public/modules/shared/initialization.service.spec.ts
@@ -20,8 +20,8 @@ import {
 } from './widget-config';
 
 import {
-  ConfigExtension
-} from './config.extension';
+  InitializationConfigExtensionService
+} from './initialization-config-extension.service';
 
 import {
   of
@@ -126,7 +126,8 @@ describe('HelpInitializationService', () => {
   }));
 
   it('should call BBHelpClient.load with config from given extension', fakeAsync(() => {
-    const extensionSpy: jasmine.SpyObj<ConfigExtension> = jasmine.createSpyObj('ConfigExtension', ['extend']);
+    const extensionSpy: jasmine.SpyObj<InitializationConfigExtensionService> =
+      jasmine.createSpyObj('InitializationConfigExtensionService', ['extend']);
     const expectedConfig: HelpWidgetConfig = {caseCentralUrl: 'https://case.centr.al'};
     extensionSpy.extend.and.returnValue(of(expectedConfig));
     const initializationService = new HelpInitializationService(buildWindow(), buildConfig(), extensionSpy);

--- a/src/app/public/modules/shared/initialization.service.spec.ts
+++ b/src/app/public/modules/shared/initialization.service.spec.ts
@@ -32,96 +32,102 @@ import {
   tick
 } from '@angular/core/testing';
 
-const NO_OP_FUNC: Function = () => {
-};
-
 describe('HelpInitializationService', () => {
 
   beforeEach(() => {
-    spyOn(BBHelpClient, 'load').and.callFake(NO_OP_FUNC);
+    spyOn(BBHelpClient, 'load').and.returnValue(Promise.resolve());
   });
 
-  it('should call BBHelpClient.load with the given config', () => {
+  it('should call BBHelpClient.load with the given config', fakeAsync(() => {
     const initializationService = new HelpInitializationService(buildWindow(), buildConfig());
     const givenConfig: HelpWidgetConfig = {productId: 'test_id'};
     initializationService.load(givenConfig);
+    tick();
     expect(BBHelpClient.load).toHaveBeenCalledWith(givenConfig);
-  });
+  }));
 
-  it('should call BBHelpClient.load with svcid from SkyAppConfig', () => {
+  it('should call BBHelpClient.load with svcid from SkyAppConfig', fakeAsync(() => {
     const svcid = 'svcid';
     const initializationService = new HelpInitializationService(buildWindow(), buildConfig({svcid: svcid}));
     const givenConfig: HelpWidgetConfig = {productId: 'test_id'};
     const expectedConfig: HelpWidgetConfig = {...givenConfig, ...{extends: svcid}};
     initializationService.load(givenConfig);
+    tick();
     expect(BBHelpClient.load).toHaveBeenCalledWith(expectedConfig);
-  });
+  }));
 
-  it('should call BBHelpClient.load with overwritten \'extends\' value from svcid', () => {
+  it('should call BBHelpClient.load with overwritten \'extends\' value from svcid', fakeAsync(() => {
     const svcid = 'svcid';
     const initializationService = new HelpInitializationService(buildWindow(), buildConfig({svcid: svcid}));
     const givenConfig: HelpWidgetConfig = {productId: 'test_id', extends: 'extends'};
     const expectedConfig: HelpWidgetConfig = {...givenConfig, ...{extends: svcid}};
     initializationService.load(givenConfig);
+    tick();
     expect(BBHelpClient.load).toHaveBeenCalledWith(expectedConfig);
-  });
+  }));
 
-  it('should call BBHelpClient.load with envid from SkyAppConfig', () => {
+  it('should call BBHelpClient.load with envid from SkyAppConfig', fakeAsync(() => {
     const envid = 'envid';
     const initializationService = new HelpInitializationService(buildWindow(), buildConfig({envid: envid}));
     const givenConfig: HelpWidgetConfig = {productId: 'test_id'};
     const expectedConfig: HelpWidgetConfig = {...givenConfig, ...{environmentId: envid}};
     initializationService.load(givenConfig);
+    tick();
     expect(BBHelpClient.load).toHaveBeenCalledWith(expectedConfig);
-  });
+  }));
 
-  it('should call BBHelpClient.load with overwritten \'environmentId\' value from envid', () => {
+  it('should call BBHelpClient.load with overwritten \'environmentId\' value from envid', fakeAsync(() => {
     const envid = 'envid';
     const initializationService = new HelpInitializationService(buildWindow(), buildConfig({envid: envid}));
     const givenConfig: HelpWidgetConfig = {productId: 'test_id', environmentId: 'environmentId'};
     const expectedConfig: HelpWidgetConfig = {...givenConfig, ...{environmentId: envid}};
     initializationService.load(givenConfig);
+    tick();
     expect(BBHelpClient.load).toHaveBeenCalledWith(expectedConfig);
-  });
+  }));
 
-  it('should call BBHelpClient.load with single locale from SKYUX_HOST', () => {
+  it('should call BBHelpClient.load with single locale from SKYUX_HOST', fakeAsync(() => {
     const locale = 'en-US';
     const initializationService = new HelpInitializationService(buildWindow(locale), buildConfig());
     const givenConfig: HelpWidgetConfig = {productId: 'test_id'};
     const expectedConfig: HelpWidgetConfig = {...givenConfig, ...{locale: locale}};
     initializationService.load(givenConfig);
+    tick();
     expect(BBHelpClient.load).toHaveBeenCalledWith(expectedConfig);
-  });
+  }));
 
-  it('should call BBHelpClient.load with one locale when there are multiple in SKYUX_HOST', () => {
+  it('should call BBHelpClient.load with one locale when there are multiple in SKYUX_HOST', fakeAsync(() => {
     const locale = 'en-US,en-GB';
     const initializationService = new HelpInitializationService(buildWindow(locale), buildConfig());
     const givenConfig: HelpWidgetConfig = {productId: 'test_id'};
     const expectedConfig: HelpWidgetConfig = {...givenConfig, ...{locale: 'en-US'}};
     initializationService.load(givenConfig);
+    tick();
     expect(BBHelpClient.load).toHaveBeenCalledWith(expectedConfig);
-  });
+  }));
 
-  it('should call BBHelpClient.load without overwriting given locale', () => {
+  it('should call BBHelpClient.load without overwriting given locale', fakeAsync(() => {
     const windowLocale = 'en-US';
     const initializationService = new HelpInitializationService(buildWindow(windowLocale), buildConfig());
     const givenConfig: HelpWidgetConfig = {productId: 'test_id', locale: 'en-GB'};
     initializationService.load(givenConfig);
+    tick();
     expect(BBHelpClient.load).toHaveBeenCalledWith(givenConfig);
-  });
+  }));
 
-  it('should call BBHelpClient.load with empty locale when undefined value in SKYUX_HOST', () => {
+  it('should call BBHelpClient.load with empty locale when undefined value in SKYUX_HOST', fakeAsync(() => {
     const window: SkyAppWindowRef = {nativeWindow: {SKYUX_HOST: {acceptLanguage: undefined}}} as SkyAppWindowRef;
     const initializationService = new HelpInitializationService(window, buildConfig());
     const givenConfig: HelpWidgetConfig = {productId: 'test_id'};
     const expectedConfig: HelpWidgetConfig = {...givenConfig, ...{locale: ''}};
     initializationService.load(givenConfig);
+    tick();
     expect(BBHelpClient.load).toHaveBeenCalledWith(expectedConfig);
-  });
+  }));
 
   it('should call BBHelpClient.load with config from given extension', fakeAsync(() => {
     const extensionSpy: jasmine.SpyObj<ConfigExtension> = jasmine.createSpyObj('ConfigExtension', ['extend']);
-    const expectedConfig: HelpWidgetConfig = { caseCentralUrl: 'https://case.centr.al'};
+    const expectedConfig: HelpWidgetConfig = {caseCentralUrl: 'https://case.centr.al'};
     extensionSpy.extend.and.returnValue(of(expectedConfig));
     const initializationService = new HelpInitializationService(buildWindow(), buildConfig(), extensionSpy);
     const givenConfig: HelpWidgetConfig = {productId: 'test_id'};

--- a/src/app/public/modules/shared/initialization.service.spec.ts
+++ b/src/app/public/modules/shared/initialization.service.spec.ts
@@ -19,6 +19,19 @@ import {
   HelpWidgetConfig
 } from './widget-config';
 
+import {
+  ConfigExtension
+} from './config.extension';
+
+import {
+  of
+} from 'rxjs';
+
+import {
+  fakeAsync,
+  tick
+} from '@angular/core/testing';
+
 const NO_OP_FUNC: Function = () => {
 };
 
@@ -105,6 +118,18 @@ describe('HelpInitializationService', () => {
     initializationService.load(givenConfig);
     expect(BBHelpClient.load).toHaveBeenCalledWith(expectedConfig);
   });
+
+  it('should call BBHelpClient.load with config from given extension', fakeAsync(() => {
+    const extensionSpy: jasmine.SpyObj<ConfigExtension> = jasmine.createSpyObj('ConfigExtension', ['extend']);
+    const expectedConfig: HelpWidgetConfig = { caseCentralUrl: 'https://case.centr.al'};
+    extensionSpy.extend.and.returnValue(of(expectedConfig));
+    const initializationService = new HelpInitializationService(buildWindow(), buildConfig(), extensionSpy);
+    const givenConfig: HelpWidgetConfig = {productId: 'test_id'};
+    initializationService.load(givenConfig);
+    tick();
+    expect(extensionSpy.extend).toHaveBeenCalledWith(givenConfig);
+    expect(BBHelpClient.load).toHaveBeenCalledWith(expectedConfig);
+  }));
 });
 
 function buildWindow(acceptLanguage: string = undefined): SkyAppWindowRef {

--- a/src/app/public/modules/shared/initialization.service.ts
+++ b/src/app/public/modules/shared/initialization.service.ts
@@ -35,7 +35,7 @@ export class HelpInitializationService {
     @Optional() private extension: ConfigExtension = undefined
   ) { }
 
-  public load(config: HelpWidgetConfig = {}): void {
+  public load(config: HelpWidgetConfig = {}): Promise<void> {
     if (this.config.runtime.params.has('svcid')) {
       config.extends = this.config.runtime.params.get('svcid');
     }
@@ -49,7 +49,8 @@ export class HelpInitializationService {
       const languages = skyuxHost.acceptLanguage || '';
       config.locale = languages.split(',')[0];
     }
-    const newConfig: Observable<HelpWidgetConfig> = this.extension ? this.extension.extend(config) : of(config);
-    newConfig.subscribe(c => BBHelpClient.load(c));
+    const configObservable: Observable<HelpWidgetConfig> = this.extension ? this.extension.extend(config) : of(config);
+    return configObservable.toPromise()
+      .then((extendedConfig: HelpWidgetConfig) => BBHelpClient.load(extendedConfig));
   }
 }

--- a/src/app/public/modules/shared/initialization.service.ts
+++ b/src/app/public/modules/shared/initialization.service.ts
@@ -20,8 +20,8 @@ import {
 } from './widget-config';
 
 import {
-  ConfigExtension
-} from './config.extension';
+  InitializationConfigExtensionService
+} from './initialization-config-extension.service';
 
 import {
   Observable,
@@ -33,7 +33,7 @@ export class HelpInitializationService {
   public constructor(
     private windowRef: SkyAppWindowRef,
     private config: SkyAppConfig,
-    @Optional() private extension: ConfigExtension = undefined
+    @Optional() private configExtensionService: InitializationConfigExtensionService = undefined
   ) { }
 
   public load(config: HelpWidgetConfig = {}): Promise<void> {
@@ -50,7 +50,9 @@ export class HelpInitializationService {
       const languages = skyuxHost.acceptLanguage || '';
       config.locale = languages.split(',')[0];
     }
-    const configObservable: Observable<HelpWidgetConfig> = this.extension ? this.extension.extend(config) : of(config);
+    const configObservable: Observable<HelpWidgetConfig> = this.configExtensionService
+      ? this.configExtensionService.extend(config)
+      : of(config);
     return configObservable.toPromise()
       .then((extendedConfig: HelpWidgetConfig) => BBHelpClient.load(extendedConfig));
   }

--- a/src/app/public/modules/shared/initialization.service.ts
+++ b/src/app/public/modules/shared/initialization.service.ts
@@ -24,7 +24,8 @@ import {
 } from './config.extension';
 
 import {
-  Observable, of
+  Observable,
+  of
 } from 'rxjs';
 
 @Injectable()

--- a/src/app/public/modules/shared/initialization.service.ts
+++ b/src/app/public/modules/shared/initialization.service.ts
@@ -1,5 +1,6 @@
 import {
-  Injectable
+  Injectable,
+  Optional
 } from '@angular/core';
 
 import {
@@ -18,14 +19,23 @@ import {
   HelpWidgetConfig
 } from './widget-config';
 
+import {
+  ConfigExtension
+} from './config.extension';
+
+import {
+  Observable, of
+} from 'rxjs';
+
 @Injectable()
 export class HelpInitializationService {
   public constructor(
     private windowRef: SkyAppWindowRef,
-    private config: SkyAppConfig
+    private config: SkyAppConfig,
+    @Optional() private extension: ConfigExtension = undefined
   ) { }
 
-  public load(config: HelpWidgetConfig = {}) {
+  public load(config: HelpWidgetConfig = {}): void {
     if (this.config.runtime.params.has('svcid')) {
       config.extends = this.config.runtime.params.get('svcid');
     }
@@ -39,6 +49,7 @@ export class HelpInitializationService {
       const languages = skyuxHost.acceptLanguage || '';
       config.locale = languages.split(',')[0];
     }
-    return BBHelpClient.load(config);
+    const newConfig: Observable<HelpWidgetConfig> = this.extension ? this.extension.extend(config) : of(config);
+    newConfig.subscribe(c => BBHelpClient.load(c));
   }
 }


### PR DESCRIPTION
this is to allow SPAs to provide their own custom runtime logic to the config for the widget.

the way a consumer would provide their own extension logic is via:

```typescript
class MyConfigExtension extends ConfigExtension {
  public extend(config: HelpWidgetConfig): Observable<HelpWidgetConfig> {
    console.log('MyConfigExtension');
    return of(config);
  }
}

@NgModule({
  providers: [
    { provide: ConfigExtension, useClass: MyConfigExtension }
  ]
})
export class AppExtrasModule {
}
```